### PR TITLE
Experiment lock

### DIFF
--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -141,7 +141,7 @@ def test_sim(beta: float = -1000.0, use_exp_zero: bool = True) -> pd.DataFrame:
     NATIVE_BIAS: Final = 0.95
 
     # length of simulation
-    N_SIM_STEPS: Final = 100000
+    N_SIM_STEPS: Final = 5000000
 
     # maximum number of mutations to allow in the simulation.
     MAX_NUM_MUTATIONS: Final = 9

--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -115,7 +115,7 @@ def get_mlp(
     return model, report[0], report[1]
 
 
-def test_sim(beta: float = -10.0, use_exp_zero: bool = True) -> pd.DataFrame:
+def test_sim(beta: float = -30.0, use_exp_zero: bool = True) -> pd.DataFrame:
     """Trains an MLP and runs a simulation with it.
 
     Arguments:
@@ -141,7 +141,7 @@ def test_sim(beta: float = -10.0, use_exp_zero: bool = True) -> pd.DataFrame:
     NATIVE_BIAS: Final = 0.95
 
     # length of simulation
-    N_SIM_STEPS: Final = 500000
+    N_SIM_STEPS: Final = 1000000
 
     # maximum number of mutations to allow in the simulation.
     MAX_NUM_MUTATIONS: Final = 9

--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -115,7 +115,7 @@ def get_mlp(
     return model, report[0], report[1]
 
 
-def test_sim(beta: float = -1.0, use_exp_zero: bool = True) -> pd.DataFrame:
+def test_sim(beta: float = -10.0, use_exp_zero: bool = True) -> pd.DataFrame:
     """Trains an MLP and runs a simulation with it.
 
     Arguments:
@@ -132,7 +132,7 @@ def test_sim(beta: float = -1.0, use_exp_zero: bool = True) -> pd.DataFrame:
     Returns:
     -------
     A DataFrame containing the results of the simulation: amino acid choices for
-    each position, the energy of each recorded sequence, and the simultation time step
+    each position, the energy of each recorded sequence, and the simulation time step
     at which the sequence was found.
 
     """
@@ -141,7 +141,7 @@ def test_sim(beta: float = -1.0, use_exp_zero: bool = True) -> pd.DataFrame:
     NATIVE_BIAS: Final = 0.95
 
     # length of simulation
-    N_SIM_STEPS: Final = 50000000
+    N_SIM_STEPS: Final = 500000
 
     # maximum number of mutations to allow in the simulation.
     MAX_NUM_MUTATIONS: Final = 9

--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -115,7 +115,7 @@ def get_mlp(
     return model, report[0], report[1]
 
 
-def test_sim(beta: float = -100.0, use_exp_zero: bool = True) -> pd.DataFrame:
+def test_sim(beta: float = -1000.0, use_exp_zero: bool = True) -> pd.DataFrame:
     """Trains an MLP and runs a simulation with it.
 
     Arguments:

--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -141,7 +141,7 @@ def test_sim(beta: float = -1000.0, use_exp_zero: bool = True) -> pd.DataFrame:
     NATIVE_BIAS: Final = 0.95
 
     # length of simulation
-    N_SIM_STEPS: Final = 5000000
+    N_SIM_STEPS: Final = 50000000
 
     # maximum number of mutations to allow in the simulation.
     MAX_NUM_MUTATIONS: Final = 9

--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -115,7 +115,7 @@ def get_mlp(
     return model, report[0], report[1]
 
 
-def test_sim(beta: float = -30.0, use_exp_zero: bool = True) -> pd.DataFrame:
+def test_sim(beta: float = -35.0, use_exp_zero: bool = True) -> pd.DataFrame:
     """Trains an MLP and runs a simulation with it.
 
     Arguments:
@@ -141,7 +141,7 @@ def test_sim(beta: float = -30.0, use_exp_zero: bool = True) -> pd.DataFrame:
     NATIVE_BIAS: Final = 0.95
 
     # length of simulation
-    N_SIM_STEPS: Final = 1000000
+    N_SIM_STEPS: Final = 5000000
 
     # maximum number of mutations to allow in the simulation.
     MAX_NUM_MUTATIONS: Final = 9

--- a/src/mavenets/example/mlp_sim.py
+++ b/src/mavenets/example/mlp_sim.py
@@ -115,7 +115,7 @@ def get_mlp(
     return model, report[0], report[1]
 
 
-def test_sim(beta: float = -1000.0, use_exp_zero: bool = True) -> pd.DataFrame:
+def test_sim(beta: float = -1.0, use_exp_zero: bool = True) -> pd.DataFrame:
     """Trains an MLP and runs a simulation with it.
 
     Arguments:

--- a/src/mavenets/network/tune.py
+++ b/src/mavenets/network/tune.py
@@ -44,7 +44,7 @@ implemented in different child classes which define the tuning procedure.
 
 from typing import Callable, overload, Union, Tuple, Literal, TypeVar, Generic
 from .base import BaseFFN
-from torch import nn, Tensor, as_tensor, full
+from torch import nn, Tensor, full
 
 _model_T = Callable[[Tensor], Tensor]
 _T = TypeVar("_T")

--- a/src/mavenets/network/tune.py
+++ b/src/mavenets/network/tune.py
@@ -176,6 +176,7 @@ class HeadLock(nn.Module):
 
     def __init__(self, model: MHTuner[Tensor], head_index: Union[int, Tensor]) -> None:
         """Store model and head index."""
+        super().__init__()
         self.model = model
         self.register_buffer("head_index", as_tensor(head_index))
 

--- a/src/mavenets/network/tune.py
+++ b/src/mavenets/network/tune.py
@@ -174,16 +174,16 @@ class HeadLock(nn.Module):
 
     """
 
-    def __init__(self, model: MHTuner[Tensor], head_index: Union[int, Tensor]) -> None:
+    def __init__(self, model: MHTuner[Tensor], head_index: int) -> None:
         """Store model and head index."""
         super().__init__()
         self.model = model
-        self.register_buffer("head_index", as_tensor(head_index))
+        self.head_index = head_index
 
     def forward(self, inp: Tensor) -> Tensor:
         """Evaluate model with locked head index value."""
         derived_heads = full(
-            size=(inp.shape[0],), fill_value=self.head_index, device=inp.device
+            size=inp.shape[0:1], fill_value=self.head_index, device=inp.device
         )
         return self.model.forward(inp=inp, head_index=derived_heads, return_raw=False)
 

--- a/src/mavenets/sample/step.py
+++ b/src/mavenets/sample/step.py
@@ -367,7 +367,7 @@ class MetSim:
         self,
         model: Callable[[torch.Tensor], torch.Tensor],
         proposer: Callable[[torch.Tensor, int], torch.Tensor],
-        batch_size: int = 128,
+        batch_size: int = 512,
         beta: float = 1.0,
         center: Optional[torch.Tensor] = None,
         max_distance_to_center: Optional[int] = None,

--- a/src/mavenets/sample/step.py
+++ b/src/mavenets/sample/step.py
@@ -367,7 +367,7 @@ class MetSim:
         self,
         model: Callable[[torch.Tensor], torch.Tensor],
         proposer: Callable[[torch.Tensor, int], torch.Tensor],
-        batch_size: int = 512,
+        batch_size: int = 4096,
         beta: float = 1.0,
         center: Optional[torch.Tensor] = None,
         max_distance_to_center: Optional[int] = None,


### PR DESCRIPTION
Provided tools to lock a multihead model to use a preset calibration head.

Allows simulations which use a single fixed calibration head to be run. Along the way sped up simulation output significantly.